### PR TITLE
Documentation Fixes and Edits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -376,7 +376,7 @@ To do this we need to split the model updates into `groups` and then in the cons
         # maybe do an extra check here to be sure the user has permission
         # send activity to your frontend
         for request_id in subscribing_request_ids:
-            # we can send a seperate message for each subscribing request
+            # we can send a separate message for each subscribing request
             # this lets ws clients rout these messages.
             await self.send_json(dict(body=message, action=action, request_id=request_id))
         # note if we do not pass `request_id` to the `subscribe` method

--- a/djangochannelsrestframework/consumers.py
+++ b/djangochannelsrestframework/consumers.py
@@ -202,7 +202,7 @@ class AsyncAPIConsumer(AsyncJsonWebsocketConsumer, metaclass=APIConsumerMetaclas
         """
         Retrieves the action name from the json message.
 
-        Returns a tuple of the action name and the argumetns that is passed to the action.
+        Returns a tuple of the action name and the arguments that is passed to the action.
 
         Override this method if you do not want to use `{"action": "action_name"}` as the way to describe actions.
         """

--- a/djangochannelsrestframework/generics.py
+++ b/djangochannelsrestframework/generics.py
@@ -12,8 +12,8 @@ class GenericAsyncAPIConsumer(AsyncAPIConsumer):
     Base class for all other generic views, this subclasses :class:`AsyncAPIConsumer`.
 
     Attributes:
-        queryset: will be accesed when the method `get_queryset` is called.
-        serializer_class: it should correspond with the `queryset` model, it will be useded for the return response.
+        queryset: will be accessed when the method `get_queryset` is called.
+        serializer_class: it should correspond with the `queryset` model, it will be used for the return response.
         lookup_field: field used in the `get_object` method. Optional.
         lookup_url_kwarg: url parameter used it for the lookup.
     """

--- a/djangochannelsrestframework/observer/__init__.py
+++ b/djangochannelsrestframework/observer/__init__.py
@@ -70,7 +70,7 @@ def model_observer(model: Type[Model], **kwargs):
                 await self.comment_activity.subscribe(request_id=request_id)
 
 
-    If you only need to use a regulare Django Rest Framework Serializer class then there is a shorthand:
+    If you only need to use a regular Django Rest Framework Serializer class then there is a shorthand:
 
     .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,8 @@ Welcome to djangochannelsrestframework's documentation!
    :caption: Contents:
 
    introduction
-
+   tutorial/index
    examples
-   
 
 .. toctree::
    :maxdepth: 4
@@ -27,7 +26,6 @@ Welcome to djangochannelsrestframework's documentation!
    mixins
    observer/observer
    permissions
-   tutorial/index
 
 
 Indices and tables

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -9,8 +9,8 @@ Django Channels Rest Framework provides a DRF like interface for building channe
 
 
 This project can be used alongside HyperMediaChannels_ and ChannelsMultiplexer_ 
-to create a Hyper Media Style api over websockets. However Django Channels Rest Framework 
-is also a free standing framework with the goal of providing an api that is familiar to DRF users.
+to create a Hyper Media Style API over websockets. However Django Channels Rest Framework
+is also a free standing framework with the goal of providing an API that is familiar to DRF users.
 
 theY4Kman_ has developed a useful Javascript client library dcrf-client_ to use with DCRF.
 

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -55,12 +55,11 @@ This will be the directory tree at the end of the Channels Tutorial and we will 
 Creating the Models
 ---------------------
 
-We will put the following code in the ``models.py`` file, to handle current rooms, messages and current users.
+We will put the following code in the ``models.py`` file, to handle current rooms, messages, and current users.
 
 .. code-block:: python
 
     from django.db import models
-    from django.conf import settings
     from django.contrib.auth.models import AbstractUser
 
 

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -15,7 +15,13 @@ back to this tutorial.
 
 We assume that you have Django installed already and the Channels Tutorial made.
 
-This will be the directory tree at the end of the Channels Tutorial and we will add the following python files:
+Next, install DCRF into the same environment that was used to setup the Channels Tutorial.
+
+.. code-block:: bash
+
+    pip install djangochannelsrestframework
+
+This will be the directory tree at the end of the Channels Tutorial and we will add the following Python files:
     - ``serializers.py``
     - ``models.py``
     - ``routing.py``

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -139,17 +139,13 @@ In the ``consumers.py`` file we will create only the room consumer for:
 .. code-block:: python
 
     import json
-    from django.shortcuts import get_object_or_404
-    from channels.generic.websocket import AsyncWebsocketConsumer
-    from channels.db import database_sync_to_async
-    from django.utils.timezone import now
-    from django.conf import settings
-    from typing import Generator
-    from djangochannelsrestframework.generics import GenericAsyncAPIConsumer, AsyncAPIConsumer
-    from djangochannelsrestframework.observer.generics import (ObserverModelInstanceMixin, action)
-    from djangochannelsrestframework.observer import model_observer
 
-    from .models import Room, Message, User
+    from channels.db import database_sync_to_async
+    from djangochannelsrestframework.generics import GenericAsyncAPIConsumer
+    from djangochannelsrestframework.observer import model_observer
+    from djangochannelsrestframework.observer.generics import ObserverModelInstanceMixin, action
+
+    from .models import Message, Room, User
     from .serializers import MessageSerializer, RoomSerializer, UserSerializer
 
 

--- a/docs/tutorial/part_1.rst
+++ b/docs/tutorial/part_1.rst
@@ -53,7 +53,7 @@ This will be the directory tree at the end of the Channels Tutorial and we will 
 
 
 Creating the Models
----------------------
+-------------------
 
 We will put the following code in the ``models.py`` file, to handle current rooms, messages, and current users.
 
@@ -84,7 +84,16 @@ We will put the following code in the ``models.py`` file, to handle current room
 
         def __str__(self):
             return f"Message({self.user} {self.room})"
-        
+
+Update AUTH Settings
+--------------------
+
+Add the following to ``mysite/settings.py`` to properly register the new ``User`` ``Model``.
+
+.. code-block:: python
+
+    AUTH_USER_MODEL = 'chat.User'
+
 Creating the Serializers
 ------------------------
 

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -19,6 +19,7 @@ We will edit the ``index.html`` file, for posting a new room.
         </form>
     {% endblock content %}
 
+Next, edit ``urls.py``.
 
 .. code-block:: python
 

--- a/docs/tutorial/part_2.rst
+++ b/docs/tutorial/part_2.rst
@@ -41,10 +41,10 @@ We will edit the ``views.py``
 
 .. code-block:: python
 
-    from django.shortcuts import render, reverse, get_object_or_404
-    from django.views.generic import TemplateView
     from django.http import HttpResponseRedirect
-    from .models import User, Room, Message
+    from django.shortcuts import get_object_or_404, render, reverse
+
+    from .models import Room
 
     def index(request):
         if request.method == "POST":


### PR DESCRIPTION
- Remove unused imports in example code in tutorial
- Set `AUTH_USER_MODEL` properly in settings to avoid error on migration
- Move tutorial further up in the user guide to make it more accessible for new users
- Fix many typos