### PR TITLE
Install Daphne into test environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=["Django>=2.2", "channels>=3.0", "djangorestframework>=3.0"],
     extras_require={
         "tests": [
+            "channels[daphne]>3.0"
             "pytest>=7.0.1",
             "pytest-django>=4.5.2",
             "pytest-asyncio>=0.18.1",


### PR DESCRIPTION
Channels v4 made `daphne` an optional dependency: https://channels.readthedocs.io/en/stable/releases/4.0.0.html#release-notes

This PR ensures that `daphne` is installed into the `test` extra so that CI testing passes.

Related to #168 