### PR TITLE
Modernize supported Python and Django Versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install
         run: |
-          pip install ${{ matrix.django }}
+          pip install "${{ matrix.django }}"
           pip install .[tests]
       - name: Freeze
         run: pip freeze

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,17 +17,16 @@ jobs:
         python:
           - 3.8
           - 3.9
-          - 3.10.5
+          - 3.10
+          - 3.11
         django:
-          - Django==2.2
-          - Django==3.0.4
-          - Django==3.1.3
-          - Django==3.2
-          - Django==4.0.6
+          - Django>=3.2,<3.3
+          - Django>=4.1,<4.2
+          - Django>=4.2,<4.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - 3.8
-          - 3.9
-          - 3.10
-          - 3.11
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
         django:
           - Django>=3.2,<3.3
           - Django>=4.1,<4.2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["Django>=2.2", "channels>=3.0", "djangorestframework>=3.0"],
+    install_requires=["Django>=3.2", "channels>=3.0", "djangorestframework>=3.0"],
     extras_require={
         "tests": [
             "channels[daphne]>3.0"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=["Django>=2.2", "channels>=3.0", "djangorestframework>=3.0"],
     extras_require={
         "tests": [
+            "channels[daphne]>3.0"
             "pytest>=7.0.1",
             "pytest-django>=4.5.2",
             "pytest-asyncio>=0.18.1",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Django",
         "Topic :: Internet :: WWW/HTTP",
     ],


### PR DESCRIPTION
Follow on to #172 

- Add support for Python 3.11
- Drop support for [EOL Django](https://endoflife.date/django) 2.2, 3.0, 3.1, 4.0
- Add support for Django 4.1, 4.2