### PR TITLE
Update minimum supported channels to 4.0.0 and DRF to 3.12.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django Channels Rest Framework
 ==============================
 
-Django Channels Rest Framework provides a DRF like interface for building channels-v3_ websocket consumers.
+Django Channels Rest Framework provides a DRF like interface for building channels-v4_ websocket consumers.
 
 
 This project can be used alongside HyperMediaChannels_ and ChannelsMultiplexer_ to create a Hyper Media Style api over websockets. However Django Channels Rest Framework is also a free standing framework with the goal of providing an api that is familiar to DRF users.
@@ -410,7 +410,7 @@ To do this we need to split the model updates into `groups` and then in the cons
 .. _ReadTheDocs: https://djangochannelsrestframework.readthedocs.io/en/latest/
 .. _post: https://lostmoa.com/blog/DjangoChannelsRestFramework/
 .. _GenericAPIView: https://www.django-rest-framework.org/api-guide/generic-views/
-.. _channels-v3: https://channels.readthedocs.io/en/latest/
+.. _channels-v4: https://channels.readthedocs.io/en/latest/
 .. _dcrf-client: https://github.com/theY4Kman/dcrf-client
 .. _theY4Kman: https://github.com/theY4Kman
 .. _HyperMediaChannels: https://github.com/hishnash/hypermediachannels

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -5,7 +5,7 @@ Introduction
 Django Channels Rest Framework
 ------------------------------
 
-Django Channels Rest Framework provides a DRF like interface for building channels-v3_ websocket consumers.
+Django Channels Rest Framework provides a DRF like interface for building channels-v4_ websocket consumers.
 
 
 This project can be used alongside HyperMediaChannels_ and ChannelsMultiplexer_ 
@@ -33,7 +33,7 @@ DCRF is based of a fork of `Channels Api <https://github.com/linuxlewis/channels
 
 .. _post: https://lostmoa.com/blog/DjangoChannelsRestFramework/
 .. _GenericAPIView: https://www.django-rest-framework.org/api-guide/generic-views/
-.. _channels-v3: https://channels.readthedocs.io/en/latest/
+.. _channels-v4: https://channels.readthedocs.io/en/latest/
 .. _dcrf-client: https://github.com/theY4Kman/dcrf-client
 .. _theY4Kman: https://github.com/theY4Kman
 .. _HyperMediaChannels: https://github.com/hishnash/hypermediachannels

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -1,7 +1,7 @@
 Tutorial
 ========
 
-Djangochannelsrestframework allow you to use DRF serializers easily with django Channels v3. 
+Djangochannelsrestframework allow you to use DRF serializers easily with django Channels v4.
 In this tutorial we will use this library to improve the `chat tutorial
 <https://channels.readthedocs.io/en/stable/tutorial/index.html>`_ from django Channels.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-django>=2.2
+django>=3.2
 djangorestframework>=3.12.4
-channels>=3.0.3
+channels>=4.0.0
 pytest
 pytest-asyncio
 pytest-django

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["Django>=3.2", "channels>4.0.0", "djangorestframework>=3.12.4"],
+    install_requires=["Django>=3.2", "channels>=4.0.0", "djangorestframework>=3.12.4"],
     extras_require={
         "tests": [
-            "channels[daphne]>4.0.0"
+            "channels[daphne]>=4.0.0"
             "pytest>=7.0.1",
             "pytest-django>=4.5.2",
             "pytest-asyncio>=0.18.1",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=["Django>=3.2", "channels>=4.0.0", "djangorestframework>=3.12.4"],
     extras_require={
         "tests": [
-            "channels[daphne]>=4.0.0"
+            "channels[daphne]>=4.0.0",
             "pytest>=7.0.1",
             "pytest-django>=4.5.2",
             "pytest-asyncio>=0.18.1",

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["Django>=3.2", "channels>=3.0", "djangorestframework>=3.0"],
+    install_requires=["Django>=3.2", "channels>4.0.0", "djangorestframework>=3.12.4"],
     extras_require={
         "tests": [
-            "channels[daphne]>3.0"
+            "channels[daphne]>4.0.0"
             "pytest>=7.0.1",
             "pytest-django>=4.5.2",
             "pytest-asyncio>=0.18.1",


### PR DESCRIPTION
Closes #168 

- Set minimum `channels` to `4.0.0`
- Set minimum DRF to `3.12.4`

Since the CI only tests the latest version of channels and DRF, update the minimum versions to avoid users installing/locking an older version that might be incompatible since it is not tested.

@hishnash You will need to update the GitHub About section from `v3` to `v4`

<img width="336" alt="Screen Shot 2023-04-10 at 7 47 49 AM" src="https://user-images.githubusercontent.com/10340167/230896098-740bfeb1-2282-4329-84c7-4827ff694096.png">

