### PR TITLE
Allow For the creation for detached actions and methods. 

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,7 +1,10 @@
+import asyncio
+
 import pytest
 from channels.testing import WebsocketCommunicator
+from rest_framework.exceptions import Throttled
 
-from djangochannelsrestframework.decorators import action
+from djangochannelsrestframework.decorators import action, detached
 from djangochannelsrestframework.consumers import AsyncAPIConsumer
 
 
@@ -55,6 +58,209 @@ async def test_decorator():
         "action": "test_sync_action",
         "response_status": 200,
         "request_id": 10,
+    }
+
+    await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_detached_method():
+
+    results = {}
+
+    class AConsumer(AsyncAPIConsumer):
+        @action()
+        async def test_async_action(self, pk=None, **kwargs):
+            await self.detached_test_method()
+            return {"pk": pk}, 200
+
+        @detached
+        async def detached_test_method(self):
+            await asyncio.sleep(1)
+            await self.send_json({"waited": 1})
+
+    # Test a normal connection
+    communicator = WebsocketCommunicator(AConsumer(), "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.send_json_to(
+        {"action": "test_async_action", "pk": 2, "request_id": 1}
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "errors": [],
+        "data": {"pk": 2},
+        "action": "test_async_action",
+        "response_status": 200,
+        "request_id": 1,
+    }
+
+    response = await communicator.receive_json_from(timeout=2)
+
+    assert response == {"waited": 1}
+
+    await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_detached_method_cleanup():
+
+    errors = []
+
+    class AConsumer(AsyncAPIConsumer):
+        @action()
+        async def test_async_action(self, pk=None, **kwargs):
+            await self.detached_test_method()
+            return {"pk": pk}, 200
+
+        @detached
+        async def detached_test_method(self):
+            try:
+                await asyncio.sleep(1000)
+            except asyncio.CancelledError as e:
+                errors.append(e)
+                raise
+
+    # Test a normal connection
+    communicator = WebsocketCommunicator(AConsumer(), "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.send_json_to(
+        {"action": "test_async_action", "pk": 2, "request_id": 1}
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "errors": [],
+        "data": {"pk": 2},
+        "action": "test_async_action",
+        "response_status": 200,
+        "request_id": 1,
+    }
+
+    await communicator.disconnect()
+
+    assert len(errors) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_detached_action():
+
+    event = asyncio.Event()
+
+    class AConsumer(AsyncAPIConsumer):
+        @action(detached=True)
+        async def test_detached_async_action(self, pk=None, **kwargs):
+            await event.wait()
+            return {"pk": pk}, 200
+
+        @action()
+        async def test_async_action(self, pk=None, **kwargs):
+            return {"pk": pk}, 200
+
+    # Test a normal connection
+    communicator = WebsocketCommunicator(AConsumer(), "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.send_json_to(
+        {"action": "test_detached_async_action", "pk": 2, "request_id": 1}
+    )
+
+    await communicator.send_json_to(
+        {"action": "test_async_action", "pk": 3, "request_id": 2}
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "errors": [],
+        "data": {"pk": 3},
+        "action": "test_async_action",
+        "response_status": 200,
+        "request_id": 2,
+    }
+
+    event.set()
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "errors": [],
+        "data": {"pk": 2},
+        "action": "test_detached_async_action",
+        "response_status": 200,
+        "request_id": 1,
+    }
+
+    await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_error_in_detached_action():
+
+    event = asyncio.Event()
+
+    class AConsumer(AsyncAPIConsumer):
+        @action(detached=True)
+        async def test_detached_async_action(self, pk=None, **kwargs):
+            await event.wait()
+            raise Throttled()
+
+        @action()
+        async def test_async_action(self, pk=None, **kwargs):
+            return {"pk": pk}, 200
+
+    # Test a normal connection
+    communicator = WebsocketCommunicator(AConsumer(), "/testws/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected
+
+    await communicator.send_json_to(
+        {"action": "test_detached_async_action", "pk": 2, "request_id": 1}
+    )
+
+    await communicator.send_json_to(
+        {"action": "test_async_action", "pk": 3, "request_id": 2}
+    )
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "errors": [],
+        "data": {"pk": 3},
+        "action": "test_async_action",
+        "response_status": 200,
+        "request_id": 2,
+    }
+
+    event.set()
+
+    response = await communicator.receive_json_from()
+
+    assert response == {
+        "data": None,
+        "action": "test_detached_async_action",
+        "response_status": 429,
+        "errors": ["Request was throttled."],
+        "request_id": 1,
     }
 
     await communicator.disconnect()


### PR DESCRIPTION
Detached actions and methods run outside of the main consumers runloop so do not stop it from handling other actions while the method is running.


This is perfect if you have an action that needs to make an upstream (async) network request before responding to the user but you want to be able to use the web socket connection in the meantime.  

Non detached (default) actions and methods block the consumer form handling messages while they are running. 




This fixes #10 



- [x] Code up solution
- [x] Add unit tests
- [ ] Update documentation