### PR TITLE
Fix docs example to prevent SynchronousOnlyOperation in async consumers

### DIFF
--- a/docs/examples/model_observer.rst
+++ b/docs/examples/model_observer.rst
@@ -49,10 +49,10 @@ These are the important methods of the class.
     from djangochannelsrestframework.consumers import GenericAsyncAPIConsumer
     from djangochannelsrestframework.observer import model_observer
     from djangochannelsrestframework.decorators import action
-
+    from rest_framework.utils.serializer_helpers import ReturnDict
     from .serializers import UserSerializer, CommentSerializer
     from .models import User, Comment
-
+    
 
     class MyConsumer(GenericAsyncAPIConsumer):
         queryset = User.objects.all()
@@ -66,12 +66,12 @@ These are the important methods of the class.
             subscribing_request_ids=[],
             **kwargs
         ):
-            await self.send_json(dict(message.data))
+            await self.send_json(dict(message))
 
         @comment_activity.serializer
-        def comment_activity(self, instance: Comment, action, **kwargs) -> CommentSerializer:
+        def comment_activity(self, instance: Comment, action, **kwargs) -> ReturnDict:
             """This will return the comment serializer"""
-            return CommentSerializer(instance)
+            return CommentSerializer(instance).data
 
         @action()
         async def subscribe_to_comment_activity(self, request_id, **kwargs):


### PR DESCRIPTION
## Description
This PR updates the documentation example for `GenericAsyncAPIConsumer` to prevent potential `SynchronousOnlyOperation` exceptions that can occur when accessing `serializers.data` in an asynchronous context.

## Changes
- Updated `comment_activity` method to use `dict(message)` instead of `dict(message.data)`
- Modified `comment_activity` serializer method to return `ReturnDict` instead of `CommentSerializer`
- Changed the serializer method to return `serializer.data` directly, avoiding database queries in the async context

## Motivation
The original example could lead to database queries being executed in an asynchronous context when accessing `serializers.data`, potentially causing `django.core.exceptions.SynchronousOnlyOperation` exceptions. This fix ensures that the serialization happens in a synchronous context, making the example safer for use in asynchronous consumers.
