### PR TITLE
Add support for observing Many-to-Many field changes in ModelObserver

### DIFF
--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -62,11 +62,11 @@ class ModelObserver(BaseObserver):
 
         # this is used to capture the current state for the model
         post_init.connect(
-            self.post_init_receiver, sender=self.model_cls, dispatch_uid=id(self)
+            self.post_init_receiver, sender=self.model_cls, dispatch_uid=str(id(self))
         )
 
         post_save.connect(
-            self.post_save_receiver, sender=self.model_cls, dispatch_uid=id(self)
+            self.post_save_receiver, sender=self.model_cls, dispatch_uid=str(id(self))
         )
 
         for field in self.model_cls._meta.many_to_many:
@@ -77,7 +77,7 @@ class ModelObserver(BaseObserver):
             )
 
         post_delete.connect(
-            self.post_delete_receiver, sender=self.model_cls, dispatch_uid=id(self)
+            self.post_delete_receiver, sender=self.model_cls, dispatch_uid=str(id(self))
         )
 
     def post_init_receiver(self, instance: Model, **kwargs):

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -70,12 +70,13 @@ class ModelObserver(BaseObserver):
         )
         have_m2m = False
         for field in self.model_cls._meta.many_to_many:
-            m2m_changed.connect(
-                self.m2m_changed_receiver,
-                sender=field.remote_field.through,
-                dispatch_uid=f"{id(self)}-{field.name}"
-            )
-            have_m2m = True
+            if hasattr(field.remote_field, 'through'):
+                m2m_changed.connect(
+                    self.m2m_changed_receiver,
+                    sender=field.remote_field.through,
+                    dispatch_uid=f"{str(id(self))}-{self.model_cls.__name__}-{field.name}"
+                )
+                have_m2m = True
 
         post_delete.connect(
             self.post_delete_receiver, sender=self.model_cls, dispatch_uid=str(id(self))
@@ -119,20 +120,36 @@ class ModelObserver(BaseObserver):
         else:
             self.database_event(instance, Action.UPDATE)
 
-    def m2m_changed_receiver(self, action: str, instance: Model, reverse: bool, model: Type[Model], pk_set: Set[Any], **kwargs):
+    def m2m_changed_receiver(self, sender, instance: Model, action: str, reverse: bool, model: Type[Model],
+                             pk_set: Set[Any], **kwargs):
         """
         Handle many-to-many changes.
         """
-        if action not in {"post_add",  "post_remove", "post_clear"}:
+        if action not in {"post_add", "post_remove", "post_clear"} and not reverse:
+            return
+
+        if action not in {"post_add", "post_remove", "pre_clear"} and reverse:
             return
 
         target_instances = []
         if not reverse:
             target_instances.append(instance)
         else:
-            for pk in pk_set:
-                target_instances.append(model.objects.get(pk=pk))
-
+            if pk_set:
+                for pk in pk_set:
+                    target_instances.append(model.objects.get(pk=pk))
+            else:  # pre_clear case
+                related_field = next(
+                    (field for field in instance._meta.get_fields()
+                     if field.many_to_many and hasattr(field, 'through') and field.through == sender),
+                    None
+                )
+                if related_field:
+                    related_manager = getattr(instance, related_field.related_name or f"{related_field.name}_set", None)
+                    if related_manager:
+                        target_instances.extend(related_manager.all())
+        
+        target_instances = list(set(target_instances))  # remove duplicates if any
         for target_instance in target_instances:
             self.database_event(target_instance, Action.UPDATE)
 

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -10,7 +10,7 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.db import transaction
 from django.db.models import Model
-from django.db.models.signals import post_delete, post_save, post_init
+from django.db.models.signals import post_delete, post_save, post_init, m2m_changed
 from rest_framework.serializers import Serializer
 
 from djangochannelsrestframework.observer.base_observer import BaseObserver
@@ -69,6 +69,13 @@ class ModelObserver(BaseObserver):
             self.post_save_receiver, sender=self.model_cls, dispatch_uid=id(self)
         )
 
+        for field in self.model_cls._meta.many_to_many:
+            m2m_changed.connect(
+                self.m2m_changed_receiver,
+                sender=field.remote_field.through,
+                dispatch_uid=f"{id(self)}-{field.name}"
+            )
+
         post_delete.connect(
             self.post_delete_receiver, sender=self.model_cls, dispatch_uid=id(self)
         )
@@ -99,6 +106,23 @@ class ModelObserver(BaseObserver):
             self.database_event(instance, Action.CREATE)
         else:
             self.database_event(instance, Action.UPDATE)
+
+    def m2m_changed_receiver(self, action: str, instance: Model, reverse: bool, model: Type[Model], pk_set: Set[Any], **kwargs):
+        """
+        Handle many-to-many changes.
+        """
+        if action not in {"post_add",  "post_remove", "post_clear"}:
+            return
+
+        target_instances = []
+        if not reverse:
+            target_instances.append(instance)
+        else:
+            for pk in pk_set:
+                target_instances.append(model.objects.get(pk=pk))
+
+        for target_instance in target_instances:
+            self.database_event(target_instance, Action.UPDATE)
 
     def post_delete_receiver(self, instance: Model, **kwargs):
         self.database_event(instance, Action.DELETE)

--- a/djangochannelsrestframework/observer/model_observer.py
+++ b/djangochannelsrestframework/observer/model_observer.py
@@ -68,17 +68,29 @@ class ModelObserver(BaseObserver):
         post_save.connect(
             self.post_save_receiver, sender=self.model_cls, dispatch_uid=str(id(self))
         )
-
+        have_m2m = False
         for field in self.model_cls._meta.many_to_many:
             m2m_changed.connect(
                 self.m2m_changed_receiver,
                 sender=field.remote_field.through,
                 dispatch_uid=f"{id(self)}-{field.name}"
             )
+            have_m2m = True
 
         post_delete.connect(
             self.post_delete_receiver, sender=self.model_cls, dispatch_uid=str(id(self))
         )
+
+        if have_m2m:
+            warnings.warn(
+                "Model observation with many-to-many fields is partially supported. " +
+                "If you delete a related object, the signal will not be sent. " +
+                "This is a Django bug that is over 10 years old: https://code.djangoproject.com/ticket/17688. " +
+                "Also, when working with many-to-many fields, Django uses savepoints, " +
+                "working with which is non-deterministic and can lead to unexpected results, " +
+                "as we do not support them.",
+                UnsupportedWarning,
+            )
 
     def post_init_receiver(self, instance: Model, **kwargs):
 

--- a/tests/test_generic_consumer.py
+++ b/tests/test_generic_consumer.py
@@ -1,4 +1,6 @@
 import pytest
+from channels.layers import channel_layers
+from channels import DEFAULT_CHANNEL_LAYER
 from channels.db import database_sync_to_async
 from tests.communicator import connected_communicator
 from django.contrib.auth import get_user_model
@@ -21,7 +23,16 @@ from djangochannelsrestframework.mixins import (
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_generic_consumer():
+async def test_generic_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+    
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+    
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -86,7 +97,16 @@ async def test_generic_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_create_mixin_consumer():
+async def test_create_mixin_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+    
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -130,7 +150,16 @@ async def test_create_mixin_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_list_mixin_consumer():
+async def test_list_mixin_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -186,7 +215,16 @@ async def test_list_mixin_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_list_mixin_consumer_with_pagination():
+async def test_list_mixin_consumer_with_pagination(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -291,7 +329,16 @@ async def test_list_mixin_consumer_with_pagination():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_stream_paginated_list_mixin():
+async def test_stream_paginated_list_mixin(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -389,7 +436,16 @@ async def test_stream_paginated_list_mixin():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_retrieve_mixin_consumer():
+async def test_retrieve_mixin_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -460,7 +516,16 @@ async def test_retrieve_mixin_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_update_mixin_consumer():
+async def test_update_mixin_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -533,7 +598,16 @@ async def test_update_mixin_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_patch_mixin_consumer():
+async def test_patch_mixin_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()
@@ -606,7 +680,16 @@ async def test_patch_mixin_consumer():
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_delete_mixin_consumer():
+async def test_delete_mixin_consumer(settings):
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
     class UserSerializer(serializers.ModelSerializer):
         class Meta:
             model = get_user_model()

--- a/tests/test_model_observer.py
+++ b/tests/test_model_observer.py
@@ -530,13 +530,10 @@ async def test_observer_model_instance_mixin_with_many_subs(settings):
         }
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(transaction=False)
 @pytest.mark.asyncio
 async def test_m2m_observer(settings):
-    """
-    This tests
-    """
-
+    
     settings.CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels.layers.InMemoryChannelLayer",
@@ -558,185 +555,188 @@ async def test_m2m_observer(settings):
 
     # Test a normal connection
     async with connected_communicator(TestConsumerMultipleSubs()) as communicator:
-
-        u1 = await database_sync_to_async(get_user_model().objects.create)(
-            username="test1", email="42@example.com"
-        )
-
-        u2 = await database_sync_to_async(get_user_model().objects.create)(
-            username="test2", email="45@example.com"
-        )
-
-        # Subscribe to instance user 1
-        await communicator.send_json_to(
-            {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
-        )
-
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "subscribe_instance",
-            "errors": [],
-            "response_status": 201,
-            "request_id": 4,
-            "data": None,
-        }
-
-        g1 = await database_sync_to_async(Group.objects.create)(name="group1")
-        g2 = await database_sync_to_async(Group.objects.create)(name="group2")
-        g3 = await database_sync_to_async(Group.objects.create)(name="group3")
-        g4 = await database_sync_to_async(Group.objects.create)(name="group4")
-
-        await database_sync_to_async(u1.groups.add)(g1, g2)
-
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g1.id, g2.id]
-            },
-        }
-
-        await database_sync_to_async(u2.groups.add)(g4)
-
-        await communicator.receive_nothing()
-
-        await database_sync_to_async(g1.user_set.add)(u2)
-
-        await communicator.receive_nothing()
-
-        await database_sync_to_async(g3.user_set.add)(u1, u2)
-
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g1.id, g2.id, g3.id]
-            },
-        }
-
-        await database_sync_to_async(g1.user_set.remove)(u1)
-
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g2.id, g3.id]
-            },
-        }
-
-        await database_sync_to_async(u1.groups.clear)()
-
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": []
-            },
-        }
-
-        await database_sync_to_async(u2.groups.clear)()
-
-        await communicator.receive_nothing()
-
-        await database_sync_to_async(u1.groups.set)([g1, g4])
-
-        response = await communicator.receive_json_from()
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g1.id, g4.id]
-            },
-        }
-
-        await database_sync_to_async(u2.groups.set)([g1, g4])
-
-        await communicator.receive_nothing()
-        
-        await database_sync_to_async(u1.groups.set)([g1, g2, g3, g4])
-        
-        response = await communicator.receive_json_from()
-        
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g1.id, g2.id, g3.id, g4.id]
-            },
-        }
-        
-        await database_sync_to_async(g4.user_set.clear)()
-        
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g1.id, g2.id, g3.id]
-            },
-        }
-
-        await database_sync_to_async(g3.user_set.remove)(u1)
-        
-        response = await communicator.receive_json_from()
-
-        assert response == {
-            "action": "update",
-            "errors": [],
-            "response_status": 200,
-            "request_id": 4,
-            "data": {
-                "email": "42@example.com",
-                "id": u1.id,
-                "username": "test1",
-                "groups": [g1.id, g2.id]
-            },
-        }
+        try:
+            u1 = await database_sync_to_async(get_user_model().objects.create)(
+                username="test1", email="42@example.com"
+            )
+    
+            u2 = await database_sync_to_async(get_user_model().objects.create)(
+                username="test2", email="45@example.com"
+            )
+    
+            # Subscribe to instance user 1
+            await communicator.send_json_to(
+                {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
+            )
+    
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "subscribe_instance",
+                "errors": [],
+                "response_status": 201,
+                "request_id": 4,
+                "data": None,
+            }
+    
+            g1 = await database_sync_to_async(Group.objects.create)(name="group1")
+            g2 = await database_sync_to_async(Group.objects.create)(name="group2")
+            g3 = await database_sync_to_async(Group.objects.create)(name="group3")
+            g4 = await database_sync_to_async(Group.objects.create)(name="group4")
+    
+            await database_sync_to_async(u1.groups.add)(g1, g2)
+    
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g1.id, g2.id]
+                },
+            }
+    
+            await database_sync_to_async(u2.groups.add)(g4)
+    
+            await communicator.receive_nothing()
+    
+            await database_sync_to_async(g1.user_set.add)(u2)
+    
+            await communicator.receive_nothing()
+    
+            await database_sync_to_async(g3.user_set.add)(u1, u2)
+    
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g1.id, g2.id, g3.id]
+                },
+            }
+    
+            await database_sync_to_async(g1.user_set.remove)(u1)
+    
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g2.id, g3.id]
+                },
+            }
+    
+            await database_sync_to_async(u1.groups.clear)()
+    
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": []
+                },
+            }
+    
+            await database_sync_to_async(u2.groups.clear)()
+    
+            await communicator.receive_nothing()
+    
+            await database_sync_to_async(u1.groups.set)([g1, g4])
+    
+            response = await communicator.receive_json_from()
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g1.id, g4.id]
+                },
+            }
+    
+            await database_sync_to_async(u2.groups.set)([g1, g4])
+    
+            await communicator.receive_nothing()
+            
+            await database_sync_to_async(u1.groups.set)([g1, g2, g3, g4])
+            
+            response = await communicator.receive_json_from()
+            
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g1.id, g2.id, g3.id, g4.id]
+                },
+            }
+            
+            await database_sync_to_async(g4.user_set.clear)()
+            
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g1.id, g2.id, g3.id]
+                },
+            }
+    
+            await database_sync_to_async(g3.user_set.remove)(u1)
+            
+            response = await communicator.receive_json_from()
+    
+            assert response == {
+                "action": "update",
+                "errors": [],
+                "response_status": 200,
+                "request_id": 4,
+                "data": {
+                    "email": "42@example.com",
+                    "id": u1.id,
+                    "username": "test1",
+                    "groups": [g1.id, g2.id]
+                },
+            }
+        finally:
+            await database_sync_to_async(get_user_model().objects.all().delete)()
+            await database_sync_to_async(Group.objects.all().delete)()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -879,7 +879,7 @@ async def test_multiple_changes_within_transaction(settings):
                 "errors": [],
                 "response_status": 200,
                 "request_id": 4,
-                "data": {"email": "42@example.com", "id": u1.id, "username": "thenewname3"},
+                "data": {"email": "42@example.com", "id": u1.id, "username": "thenewname3", "groups": []},
             }]
         finally:
             await database_sync_to_async(u1.delete)()

--- a/tests/test_model_observer.py
+++ b/tests/test_model_observer.py
@@ -1,6 +1,8 @@
+import asyncio
 from contextlib import AsyncExitStack
 
 import pytest
+from django.contrib.auth.models import Group
 from channels import DEFAULT_CHANNEL_LAYER
 from channels.db import database_sync_to_async
 from channels.layers import channel_layers
@@ -23,6 +25,7 @@ class UserSerializer(serializers.ModelSerializer):
             "id",
             "username",
             "email",
+            "groups",
         )
 
 
@@ -106,7 +109,7 @@ async def test_observer_model_instance_mixin(settings):
             "errors": [],
             "response_status": 200,
             "request_id": 1,
-            "data": {"email": "42@example.com", "id": u1.id, "username": "test1"},
+            "data": {"email": "42@example.com", "id": u1.id, "username": "test1", "groups": []},
         }
 
         # lookup up u1
@@ -155,7 +158,7 @@ async def test_observer_model_instance_mixin(settings):
             "errors": [],
             "response_status": 200,
             "request_id": 4,
-            "data": {"email": "42@example.com", "id": u1.id, "username": "thenewname"},
+            "data": {"email": "42@example.com", "id": u1.id, "username": "thenewname", "groups": []},
         }
 
         u1_pk = u1.pk
@@ -350,7 +353,7 @@ async def test_unsubscribe_observer_model_instance_mixin(settings):
             "errors": [],
             "response_status": 200,
             "request_id": 4,
-            "data": {"email": "42@example.com", "id": u1.pk, "username": "thenewname"},
+            "data": {"email": "42@example.com", "id": u1.pk, "username": "thenewname", "groups": []},
         } in [a, b]
 
         # unsubscribe
@@ -492,7 +495,7 @@ async def test_observer_model_instance_mixin_with_many_subs(settings):
             "errors": [],
             "response_status": 200,
             "request_id": 4,
-            "data": {"email": "42@example.com", "id": u1.id, "username": "new name"},
+            "data": {"email": "42@example.com", "id": u1.id, "username": "new name", "groups": []},
         }
 
         assert await communicator.receive_nothing()
@@ -524,8 +527,166 @@ async def test_observer_model_instance_mixin_with_many_subs(settings):
             "errors": [],
             "response_status": 200,
             "request_id": 5,
-            "data": {"email": "45@example.com", "id": u2.id, "username": "the new name 2"},
+            "data": {"email": "45@example.com", "id": u2.id, "username": "the new name 2", "groups": []},
         }
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_m2m_observer(settings):
+    """
+    This tests
+    """
+
+    settings.CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+            "TEST_CONFIG": {"expiry": 100500},
+        },
+    }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
+
+    class TestConsumerMultipleSubs(ObserverModelInstanceMixin, GenericAsyncAPIConsumer):
+
+        queryset = get_user_model().objects.all()
+        serializer_class = UserSerializer
+
+        async def accept(self, subprotocol=None):
+            await super().accept()
+
+    assert not await database_sync_to_async(get_user_model().objects.all().exists)()
+
+    # Test a normal connection
+    async with connected_communicator(TestConsumerMultipleSubs()) as communicator:
+
+        u1 = await database_sync_to_async(get_user_model().objects.create)(
+            username="test1", email="42@example.com"
+        )
+
+        u2 = await database_sync_to_async(get_user_model().objects.create)(
+            username="test2", email="45@example.com"
+        )
+
+        # Subscribe to instance user 1
+        await communicator.send_json_to(
+            {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
+        )
+
+        response = await communicator.receive_json_from()
+
+        assert response == {
+            "action": "subscribe_instance",
+            "errors": [],
+            "response_status": 201,
+            "request_id": 4,
+            "data": None,
+        }
+
+        g1 = await database_sync_to_async(Group.objects.create)(name="group1")
+        g2 = await database_sync_to_async(Group.objects.create)(name="group2")
+        g3 = await database_sync_to_async(Group.objects.create)(name="group3")
+        g4 = await database_sync_to_async(Group.objects.create)(name="group4")
+
+        await database_sync_to_async(u1.groups.add)(g1, g2)
+
+        response = await communicator.receive_json_from()
+
+        assert response == {
+            "action": "update",
+            "errors": [],
+            "response_status": 200,
+            "request_id": 4,
+            "data": {
+                "email": "42@example.com",
+                "id": u1.id,
+                "username": "test1",
+                "groups": [g1.id, g2.id]
+            },
+        }
+
+        await database_sync_to_async(u2.groups.add)(g4)
+
+        await communicator.receive_nothing()
+
+        await database_sync_to_async(g1.user_set.add)(u2)
+
+        await communicator.receive_nothing()
+
+        await database_sync_to_async(g3.user_set.add)(u1, u2)
+
+        response = await communicator.receive_json_from()
+
+        assert response == {
+            "action": "update",
+            "errors": [],
+            "response_status": 200,
+            "request_id": 4,
+            "data": {
+                "email": "42@example.com",
+                "id": u1.id,
+                "username": "test1",
+                "groups": [g1.id, g2.id, g3.id]
+            },
+        }
+
+        await database_sync_to_async(g1.user_set.remove)(u1)
+
+        response = await communicator.receive_json_from()
+
+        assert response == {
+            "action": "update",
+            "errors": [],
+            "response_status": 200,
+            "request_id": 4,
+            "data": {
+                "email": "42@example.com",
+                "id": u1.id,
+                "username": "test1",
+                "groups": [g2.id, g3.id]
+            },
+        }
+
+        await database_sync_to_async(u1.groups.clear)()
+
+        response = await communicator.receive_json_from()
+
+        assert response == {
+            "action": "update",
+            "errors": [],
+            "response_status": 200,
+            "request_id": 4,
+            "data": {
+                "email": "42@example.com",
+                "id": u1.id,
+                "username": "test1",
+                "groups": []
+            },
+        }
+
+        await database_sync_to_async(u2.groups.clear)()
+
+        await communicator.receive_nothing()
+
+        await database_sync_to_async(u1.groups.set)([g1, g4])
+
+        response = await communicator.receive_json_from()
+        assert response == {
+            "action": "update",
+            "errors": [],
+            "response_status": 200,
+            "request_id": 4,
+            "data": {
+                "email": "42@example.com",
+                "id": u1.id,
+                "username": "test1",
+                "groups": [g1.id, g4.id]
+            },
+        }
+
+        await database_sync_to_async(u2.groups.set)([g1, g4])
+
+        await communicator.receive_nothing()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -560,14 +721,14 @@ async def test_current_groups_updated_on_commit(settings):
     consumer = TestConsumer()
 
     async with connected_communicator(consumer) as communicator:
-        
+
         u1 = await database_sync_to_async(get_user_model().objects.create)(
             username="test1", email="42@example.com"
         )
 
         def get_current_groups():
             return consumer.handle_instance_change.get_observer_state(u1).current_groups
-        
+
         async def aget_current_groups():
             return await database_sync_to_async(get_current_groups)()
 
@@ -594,7 +755,7 @@ async def test_current_groups_updated_on_commit(settings):
                 u1.delete()
                 assert get_current_groups() == current_groups
             assert get_current_groups() != current_groups
-        
+
         await check_group_names_in_tx()
 
 
@@ -636,9 +797,9 @@ async def test_multiple_changes_within_transaction(settings):
             await communicator.send_json_to(
                 {"action": "subscribe_instance", "pk": u1.id, "request_id": 4}
             )
-    
+
             response = await communicator.receive_json_from()
-    
+
             assert response == {
                 "action": "subscribe_instance",
                 "errors": [],
@@ -646,9 +807,9 @@ async def test_multiple_changes_within_transaction(settings):
                 "request_id": 4,
                 "data": None,
             }
-    
+
             await communicator.receive_many_json_from()
-    
+
             @database_sync_to_async
             def change_username_in_tx():
                 with transaction.atomic():
@@ -658,11 +819,11 @@ async def test_multiple_changes_within_transaction(settings):
                     u1.save()
                     u1.username = "thenewname3"
                     u1.save()
-            
+
             await change_username_in_tx()
-            
+
             response = await communicator.receive_many_json_from()
-    
+
             assert response == [{
                 "action": "update",
                 "errors": [],

--- a/tests/test_model_with_custom_pk_observer.py
+++ b/tests/test_model_with_custom_pk_observer.py
@@ -1,9 +1,10 @@
-import asyncio
-from http.client import responses
 from typing import Dict
 
 import pytest
+from channels import DEFAULT_CHANNEL_LAYER
 from channels.db import database_sync_to_async
+from channels.layers import channel_layers
+
 from tests.communicator import connected_communicator
 from rest_framework import serializers
 
@@ -25,6 +26,8 @@ async def test_subscription_create_notification(settings):
             },
         },
     }
+
+    layer = channel_layers.make_test_backend(DEFAULT_CHANNEL_LAYER)
 
     class TestSerializer(serializers.ModelSerializer):
         class Meta:


### PR DESCRIPTION
### Description:  
This PR introduces functionality for handling `m2m_changed` signals within the `ModelObserver` class, enabling observation of changes in many-to-many relationships.  

**Note**: This PR is dependent on [#208](https://github.com/NilCoalescing/djangochannelsrestframework/pull/208) and must be reviewed and merged only after it. It is based on the commits from that PR.  

#### Key Changes:  
1. Added a new signal handler (`m2m_changed_receiver`) to handle `m2m_changed` events for many-to-many fields.  
2. Updated the `_connect` method to dynamically register `m2m_changed` signals for all many-to-many fields in the observed model.  
3. Ensured appropriate messages are generated and sent for `post_add`, `post_remove`, and `post_clear` actions.  
4. Added warnings to highlight the limitations of many-to-many observation due to known Django issues with related object deletions and savepoint behavior.  

#### Additional Notes:  
- The implementation includes a warning (`UnsupportedWarning`) to inform users about potential non-deterministic behavior when savepoints are used in transactions.  
- Comprehensive test coverage has been added to validate the new functionality.  
- Documentation for `ModelObserver` should be updated to reflect support for many-to-many field observation and its known limitations.  

This enhancement improves the versatility of the `ModelObserver`, allowing for more robust real-time updates in applications with many-to-many relationships.