### PR TITLE
check request_id exists in request_ids before remove

### DIFF
--- a/djangochannelsrestframework/observer/generics.py
+++ b/djangochannelsrestframework/observer/generics.py
@@ -72,7 +72,8 @@ class ObserverConsumerMixin(metaclass=ObserverAPIConsumerMetaclass):
     def _unsubscribe(self, request_id: str):
         to_remove = []
         for group, request_ids in self.subscribed_requests.items():
-            request_ids.remove(request_id)
+            if request_id in request_ids:
+                request_ids.remove(request_id)
             if not request_ids:
                 to_remove.append(group)
 


### PR DESCRIPTION
This will help to silently ignore unsubscribe requests for request ids which do not exist.